### PR TITLE
Add GitHub Copilot provider

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -40,6 +40,7 @@ import {
 import {
   getApiKey as fetchApiKey,
   maybeRedeemCredits,
+  fetchGithubCopilotApiKey,
 } from "./utils/get-api-key";
 import { createInputItem } from "./utils/input-utils";
 import { initLogger } from "./utils/logger/log";
@@ -328,7 +329,11 @@ try {
 }
 
 if (cli.flags.login) {
-  apiKey = await fetchApiKey(client.issuer, client.client_id);
+  if (provider.toLowerCase() === "githubcopilot") {
+    apiKey = await fetchGithubCopilotApiKey();
+  } else {
+    apiKey = await fetchApiKey(client.issuer, client.client_id);
+  }
   try {
     const home = os.homedir();
     const authDir = path.join(home, ".codex");
@@ -341,7 +346,11 @@ if (cli.flags.login) {
     /* ignore */
   }
 } else if (!apiKey) {
-  apiKey = await fetchApiKey(client.issuer, client.client_id);
+  if (provider.toLowerCase() === "githubcopilot") {
+    apiKey = await fetchGithubCopilotApiKey();
+  } else {
+    apiKey = await fetchApiKey(client.issuer, client.client_id);
+  }
 }
 // Ensure the API key is available as an environment variable for legacy code
 process.env["OPENAI_API_KEY"] = apiKey;

--- a/codex-cli/src/utils/get-api-key.tsx
+++ b/codex-cli/src/utils/get-api-key.tsx
@@ -764,3 +764,25 @@ export async function getApiKey(
 }
 
 export { maybeRedeemCredits };
+
+export async function fetchGithubCopilotApiKey(): Promise<string> {
+  if (process.env["GITHUB_COPILOT_TOKEN"]) {
+    return process.env["GITHUB_COPILOT_TOKEN"]!;
+  }
+
+  const choice = await promptUserForChoice();
+  if (choice.type === "apikey") {
+    process.env["GITHUB_COPILOT_TOKEN"] = choice.key;
+    return choice.key;
+  }
+
+  // Sign in via GitHub is not yet supported; instruct the user
+  // eslint-disable-next-line no-console
+  console.error(
+    "\n" +
+      "GitHub OAuth login is not yet implemented for Codex. " +
+      "Please generate a token manually and set it as GITHUB_COPILOT_TOKEN." +
+      "\n"
+  );
+  process.exit(1);
+}

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -52,4 +52,9 @@ export const providers: Record<
     baseURL: "https://conductor.arcee.ai/v1",
     envKey: "ARCEEAI_API_KEY",
   },
+  githubcopilot: {
+    name: "GitHubCopilot",
+    baseURL: "https://copilot-proxy.githubusercontent.com/v1",
+    envKey: "GITHUB_COPILOT_TOKEN",
+  },
 };


### PR DESCRIPTION
## Summary
- add `githubcopilot` provider configuration
- allow login via `fetchGithubCopilotApiKey`
- call provider-specific login in CLI

## Testing
- `pnpm build`
- `pnpm test` *(fails: raw-exec-process-group.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_684f237b111083268d65d4f2fd75eac8