### PR TITLE
Add GitHub Copilot provider support

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -39,8 +39,8 @@ import {
 } from "./utils/config";
 import {
   getApiKey as fetchApiKey,
+  getGithubCopilotApiKey as fetchGithubCopilotApiKey,
   maybeRedeemCredits,
-  fetchGithubCopilotApiKey,
 } from "./utils/get-api-key";
 import { createInputItem } from "./utils/input-utils";
 import { initLogger } from "./utils/logger/log";
@@ -323,12 +323,38 @@ try {
     if (data.OPENAI_API_KEY && !expired) {
       apiKey = data.OPENAI_API_KEY;
     }
+    if (
+      data.GITHUBCOPILOT_API_KEY &&
+      provider.toLowerCase() === "githubcopilot"
+    ) {
+      apiKey = data.GITHUBCOPILOT_API_KEY;
+    }
   }
 } catch {
   // ignore errors
 }
 
-if (cli.flags.login) {
+if (provider.toLowerCase() === "githubcopilot" && !apiKey) {
+  apiKey = await fetchGithubCopilotApiKey();
+  try {
+    const home = os.homedir();
+    const authDir = path.join(home, ".codex");
+    const authFile = path.join(authDir, "auth.json");
+    fs.writeFileSync(
+      authFile,
+      JSON.stringify(
+        {
+          GITHUBCOPILOT_API_KEY: apiKey,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+  } catch {
+    /* ignore */
+  }
+} else if (cli.flags.login) {
   if (provider.toLowerCase() === "githubcopilot") {
     apiKey = await fetchGithubCopilotApiKey();
   } else {
@@ -353,7 +379,7 @@ if (cli.flags.login) {
   }
 }
 // Ensure the API key is available as an environment variable for legacy code
-process.env["OPENAI_API_KEY"] = apiKey;
+process.env[`${provider.toUpperCase()}_API_KEY`] = apiKey;
 
 if (cli.flags.free) {
   // eslint-disable-next-line no-console

--- a/codex-cli/src/utils/openai-client.ts
+++ b/codex-cli/src/utils/openai-client.ts
@@ -1,4 +1,6 @@
 import type { AppConfig } from "./config.js";
+import type { ClientOptions } from "openai";
+import type * as Core from "openai/core";
 
 import {
   getBaseUrl,
@@ -9,6 +11,7 @@ import {
   OPENAI_PROJECT,
 } from "./config.js";
 import OpenAI, { AzureOpenAI } from "openai";
+import * as Errors from "openai/error";
 
 type OpenAIClientConfig = {
   provider: string;
@@ -42,10 +45,166 @@ export function createOpenAIClient(
     });
   }
 
+  if (config.provider?.toLowerCase() === "githubcopilot") {
+    return new GithubCopilotClient({
+      apiKey: getApiKey(config.provider),
+      baseURL: getBaseUrl(config.provider),
+      timeout: OPENAI_TIMEOUT_MS,
+      defaultHeaders: headers,
+    });
+  }
+
   return new OpenAI({
     apiKey: getApiKey(config.provider),
     baseURL: getBaseUrl(config.provider),
     timeout: OPENAI_TIMEOUT_MS,
     defaultHeaders: headers,
   });
+}
+
+export class GithubCopilotClient extends OpenAI {
+  private copilotToken: string | null = null;
+  private copilotTokenExpiration = new Date();
+  private githubAPIKey: string;
+
+  constructor(opts: ClientOptions = {}) {
+    super(opts);
+    if (!opts.apiKey) {
+      throw new Errors.OpenAIError("missing github copilot token");
+    }
+    this.githubAPIKey = opts.apiKey;
+  }
+
+  private async _getGithubCopilotToken(): Promise<string | undefined> {
+    if (
+      this.copilotToken &&
+      this.copilotTokenExpiration.getTime() > Date.now()
+    ) {
+      return this.copilotToken;
+    }
+    const resp = await fetch(
+      "https://api.github.com/copilot_internal/v2/token",
+      {
+        method: "GET",
+        headers: GithubCopilotClient._mergeGithubHeaders({
+          "Authorization": `bearer ${this.githubAPIKey}`,
+          "Accept": "application/json",
+          "Content-Type": "application/json",
+        }),
+      },
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error("unable to get github copilot auth token: " + text);
+    }
+    const text = await resp.text();
+    const { token, refresh_in } = JSON.parse(text);
+    if (typeof token !== "string" || typeof refresh_in !== "number") {
+      throw new Errors.OpenAIError(
+        `unexpected response from copilot auth: ${text}`,
+      );
+    }
+    this.copilotToken = token;
+    this.copilotTokenExpiration = new Date(Date.now() + refresh_in * 1000);
+    return token;
+  }
+
+  protected override authHeaders(
+    _opts: Core.FinalRequestOptions,
+  ): Core.Headers {
+    return {};
+  }
+
+  protected override async prepareOptions(
+    opts: Core.FinalRequestOptions<unknown>,
+  ): Promise<void> {
+    const token = await this._getGithubCopilotToken();
+    opts.headers ??= {};
+    if (token) {
+      opts.headers["Authorization"] = `Bearer ${token}`;
+      opts.headers = GithubCopilotClient._mergeGithubHeaders(opts.headers);
+    } else {
+      throw new Errors.OpenAIError("Unable to handle auth");
+    }
+    return super.prepareOptions(opts);
+  }
+
+  static async getLoginURL(): Promise<{
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+  }> {
+    const resp = await fetch("https://github.com/login/device/code", {
+      method: "POST",
+      headers: this._mergeGithubHeaders({
+        "Content-Type": "application/json",
+        "accept": "application/json",
+      }),
+      body: JSON.stringify({
+        client_id: "Iv1.b507a08c87ecfe98",
+        scope: "read:user",
+      }),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Errors.OpenAIError("Unable to get login device code: " + text);
+    }
+    return resp.json();
+  }
+
+  static async pollForAccessToken(deviceCode: string): Promise<string> {
+    /*eslint no-await-in-loop: "off"*/
+    const MAX_ATTEMPTS = 36;
+    let lastErr: unknown = null;
+    for (let i = 0; i < MAX_ATTEMPTS; ++i) {
+      try {
+        const resp = await fetch(
+          "https://github.com/login/oauth/access_token",
+          {
+            method: "POST",
+            headers: this._mergeGithubHeaders({
+              "Content-Type": "application/json",
+              "accept": "application/json",
+            }),
+            body: JSON.stringify({
+              client_id: "Iv1.b507a08c87ecfe98",
+              device_code: deviceCode,
+              grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+            }),
+          },
+        );
+        if (!resp.ok) {
+          continue;
+        }
+        const info = await resp.json();
+        if (info.access_token) {
+          return info.access_token as string;
+        } else if (info.error === "authorization_pending") {
+          lastErr = null;
+        } else {
+          throw new Errors.OpenAIError(
+            "unexpected response when polling for access token: " +
+              JSON.stringify(info),
+          );
+        }
+      } catch (err) {
+        lastErr = err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+    }
+    throw new Errors.OpenAIError(
+      "timed out waiting for access token",
+      lastErr != null ? { cause: lastErr } : {},
+    );
+  }
+
+  private static _mergeGithubHeaders<
+    T extends Core.Headers | Record<string, string>,
+  >(headers: T): T {
+    const copy = { ...headers } as Record<string, string> & T;
+    copy["User-Agent"] = "GithubCopilot/1.155.0";
+    copy["editor-version"] = "vscode/1.85.1";
+    copy["editor-plugin-version"] = "copilot/1.155.0";
+    return copy as T;
+  }
 }

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -53,8 +53,8 @@ export const providers: Record<
     envKey: "ARCEEAI_API_KEY",
   },
   githubcopilot: {
-    name: "GitHubCopilot",
-    baseURL: "https://copilot-proxy.githubusercontent.com/v1",
-    envKey: "GITHUB_COPILOT_TOKEN",
+    name: "GithubCopilot",
+    baseURL: "https://api.githubcopilot.com",
+    envKey: "GITHUBCOPILOT_API_KEY",
   },
 };


### PR DESCRIPTION
## Summary
- handle login via GitHub device flow
- save Copilot token in auth.json
- create `GithubCopilotClient` for Copilot API requests
- initialize Copilot client in agent loop
- expose `githubcopilot` provider configuration

## Testing
- `pnpm --filter @openai/codex run format`
- `pnpm --filter @openai/codex run lint`
- `pnpm --filter @openai/codex run test` *(fails: Process with PID XXXX failed to terminate within 500ms)*

------
https://chatgpt.com/codex/tasks/task_e_684f272bac248326a07facb43efee33f