### PR TITLE
Add GitHub Copilot provider support

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -39,8 +39,8 @@ import {
 } from "./utils/config";
 import {
   getApiKey as fetchApiKey,
+  getGithubCopilotApiKey as fetchGithubCopilotApiKey,
   maybeRedeemCredits,
-  fetchGithubCopilotApiKey,
 } from "./utils/get-api-key";
 import { createInputItem } from "./utils/input-utils";
 import { initLogger } from "./utils/logger/log";
@@ -323,12 +323,38 @@ try {
     if (data.OPENAI_API_KEY && !expired) {
       apiKey = data.OPENAI_API_KEY;
     }
+    if (
+      data.GITHUBCOPILOT_API_KEY &&
+      provider.toLowerCase() === "githubcopilot"
+    ) {
+      apiKey = data.GITHUBCOPILOT_API_KEY;
+    }
   }
 } catch {
   // ignore errors
 }
 
-if (cli.flags.login) {
+if (provider.toLowerCase() === "githubcopilot" && !apiKey) {
+  apiKey = await fetchGithubCopilotApiKey();
+  try {
+    const home = os.homedir();
+    const authDir = path.join(home, ".codex");
+    const authFile = path.join(authDir, "auth.json");
+    fs.writeFileSync(
+      authFile,
+      JSON.stringify(
+        {
+          GITHUBCOPILOT_API_KEY: apiKey,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+  } catch {
+    /* ignore */
+  }
+} else if (cli.flags.login) {
   if (provider.toLowerCase() === "githubcopilot") {
     apiKey = await fetchGithubCopilotApiKey();
   } else {
@@ -353,7 +379,7 @@ if (cli.flags.login) {
   }
 }
 // Ensure the API key is available as an environment variable for legacy code
-process.env["OPENAI_API_KEY"] = apiKey;
+process.env[`${provider.toUpperCase()}_API_KEY`] = apiKey;
 
 if (cli.flags.free) {
   // eslint-disable-next-line no-console

--- a/codex-cli/src/utils/agent/exec.ts
+++ b/codex-cli/src/utils/agent/exec.ts
@@ -120,6 +120,7 @@ export function execApplyPatch(
       stdout: result,
       stderr: "",
       exitCode: 0,
+      pid: 0,
     };
   } catch (error: unknown) {
     // @ts-expect-error error might not be an object or have a message property.
@@ -128,6 +129,7 @@ export function execApplyPatch(
       stdout: "",
       stderr: stderr,
       exitCode: 1,
+      pid: 0,
     };
   }
 }

--- a/codex-cli/src/utils/agent/sandbox/interface.ts
+++ b/codex-cli/src/utils/agent/sandbox/interface.ts
@@ -18,6 +18,8 @@ export type ExecResult = {
   stdout: string;
   stderr: string;
   exitCode: number;
+  /** PID of the spawned process. 0 if spawn failed */
+  pid: number;
 };
 
 /**

--- a/codex-cli/src/utils/agent/sandbox/raw-exec.ts
+++ b/codex-cli/src/utils/agent/sandbox/raw-exec.ts
@@ -41,6 +41,7 @@ export function exec(
       stdout: "",
       stderr: "command[0] is not a string",
       exitCode: 1,
+      pid: 0,
     });
   }
 
@@ -124,7 +125,7 @@ export function exec(
         if (!child.killed) {
           killTarget("SIGKILL");
         }
-      }, 2000).unref();
+      }, 250).unref();
     };
     if (abortSignal.aborted) {
       abortHandler();
@@ -186,6 +187,7 @@ export function exec(
         stdout,
         stderr,
         exitCode,
+        pid: child.pid ?? 0,
       };
       resolve(
         addTruncationWarningsIfNecessary(
@@ -201,6 +203,7 @@ export function exec(
         stdout: "",
         stderr: String(err),
         exitCode: 1,
+        pid: child.pid ?? 0,
       };
       resolve(
         addTruncationWarningsIfNecessary(
@@ -224,7 +227,7 @@ function addTruncationWarningsIfNecessary(
   if (!hitMaxStdout && !hitMaxStderr) {
     return execResult;
   } else {
-    const { stdout, stderr, exitCode } = execResult;
+    const { stdout, stderr, exitCode, pid } = execResult;
     return {
       stdout: hitMaxStdout
         ? stdout + "\n\n[Output truncated: too many lines or bytes]"
@@ -233,6 +236,7 @@ function addTruncationWarningsIfNecessary(
         ? stderr + "\n\n[Output truncated: too many lines or bytes]"
         : stderr,
       exitCode,
+      pid,
     };
   }
 }

--- a/codex-cli/src/utils/openai-client.ts
+++ b/codex-cli/src/utils/openai-client.ts
@@ -1,4 +1,6 @@
 import type { AppConfig } from "./config.js";
+import type { ClientOptions } from "openai";
+import type * as Core from "openai/core";
 
 import {
   getBaseUrl,
@@ -9,6 +11,7 @@ import {
   OPENAI_PROJECT,
 } from "./config.js";
 import OpenAI, { AzureOpenAI } from "openai";
+import * as Errors from "openai/error";
 
 type OpenAIClientConfig = {
   provider: string;
@@ -42,10 +45,166 @@ export function createOpenAIClient(
     });
   }
 
+  if (config.provider?.toLowerCase() === "githubcopilot") {
+    return new GithubCopilotClient({
+      apiKey: getApiKey(config.provider),
+      baseURL: getBaseUrl(config.provider),
+      timeout: OPENAI_TIMEOUT_MS,
+      defaultHeaders: headers,
+    });
+  }
+
   return new OpenAI({
     apiKey: getApiKey(config.provider),
     baseURL: getBaseUrl(config.provider),
     timeout: OPENAI_TIMEOUT_MS,
     defaultHeaders: headers,
   });
+}
+
+export class GithubCopilotClient extends OpenAI {
+  private copilotToken: string | null = null;
+  private copilotTokenExpiration = new Date();
+  private githubAPIKey: string;
+
+  constructor(opts: ClientOptions = {}) {
+    super(opts);
+    if (!opts.apiKey) {
+      throw new Errors.OpenAIError("missing github copilot token");
+    }
+    this.githubAPIKey = opts.apiKey;
+  }
+
+  private async _getGithubCopilotToken(): Promise<string | undefined> {
+    if (
+      this.copilotToken &&
+      this.copilotTokenExpiration.getTime() > Date.now()
+    ) {
+      return this.copilotToken;
+    }
+    const resp = await fetch(
+      "https://api.github.com/copilot_internal/v2/token",
+      {
+        method: "GET",
+        headers: GithubCopilotClient._mergeGithubHeaders({
+          "Authorization": `bearer ${this.githubAPIKey}`,
+          "Accept": "application/json",
+          "Content-Type": "application/json",
+        }),
+      },
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error("unable to get github copilot auth token: " + text);
+    }
+    const text = await resp.text();
+    const { token, refresh_in } = JSON.parse(text);
+    if (typeof token !== "string" || typeof refresh_in !== "number") {
+      throw new Errors.OpenAIError(
+        `unexpected response from copilot auth: ${text}`,
+      );
+    }
+    this.copilotToken = token;
+    this.copilotTokenExpiration = new Date(Date.now() + refresh_in * 1000);
+    return token;
+  }
+
+  protected override authHeaders(
+    _opts: Core.FinalRequestOptions,
+  ): Core.Headers {
+    return {};
+  }
+
+  protected override async prepareOptions(
+    opts: Core.FinalRequestOptions<unknown>,
+  ): Promise<void> {
+    const token = await this._getGithubCopilotToken();
+    opts.headers ??= {};
+    if (token) {
+      opts.headers["Authorization"] = `Bearer ${token}`;
+      opts.headers = GithubCopilotClient._mergeGithubHeaders(opts.headers);
+    } else {
+      throw new Errors.OpenAIError("Unable to handle auth");
+    }
+    return super.prepareOptions(opts);
+  }
+
+  static async getLoginURL(): Promise<{
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+  }> {
+    const resp = await fetch("https://github.com/login/device/code", {
+      method: "POST",
+      headers: this._mergeGithubHeaders({
+        "Content-Type": "application/json",
+        "accept": "application/json",
+      }),
+      body: JSON.stringify({
+        client_id: "Iv1.b507a08c87ecfe98",
+        scope: "read:user",
+      }),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Errors.OpenAIError("Unable to get login device code: " + text);
+    }
+    return resp.json();
+  }
+
+  static async pollForAccessToken(deviceCode: string): Promise<string> {
+    /*eslint no-await-in-loop: "off"*/
+    const MAX_ATTEMPTS = 36;
+    let lastErr: unknown = null;
+    for (let i = 0; i < MAX_ATTEMPTS; ++i) {
+      try {
+        const resp = await fetch(
+          "https://github.com/login/oauth/access_token",
+          {
+            method: "POST",
+            headers: this._mergeGithubHeaders({
+              "Content-Type": "application/json",
+              "accept": "application/json",
+            }),
+            body: JSON.stringify({
+              client_id: "Iv1.b507a08c87ecfe98",
+              device_code: deviceCode,
+              grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+            }),
+          },
+        );
+        if (!resp.ok) {
+          continue;
+        }
+        const info = await resp.json();
+        if (info.access_token) {
+          return info.access_token as string;
+        } else if (info.error === "authorization_pending") {
+          lastErr = null;
+        } else {
+          throw new Errors.OpenAIError(
+            "unexpected response when polling for access token: " +
+              JSON.stringify(info),
+          );
+        }
+      } catch (err) {
+        lastErr = err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+    }
+    throw new Errors.OpenAIError(
+      "timed out waiting for access token",
+      lastErr != null ? { cause: lastErr } : {},
+    );
+  }
+
+  private static _mergeGithubHeaders<
+    T extends Core.Headers | Record<string, string>,
+  >(headers: T): T {
+    const copy = { ...headers } as Record<string, string> & T;
+    copy["User-Agent"] = "GithubCopilot/1.155.0";
+    copy["editor-version"] = "vscode/1.85.1";
+    copy["editor-plugin-version"] = "copilot/1.155.0";
+    return copy as T;
+  }
 }

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -53,8 +53,8 @@ export const providers: Record<
     envKey: "ARCEEAI_API_KEY",
   },
   githubcopilot: {
-    name: "GitHubCopilot",
-    baseURL: "https://copilot-proxy.githubusercontent.com/v1",
-    envKey: "GITHUB_COPILOT_TOKEN",
+    name: "GithubCopilot",
+    baseURL: "https://api.githubcopilot.com",
+    envKey: "GITHUBCOPILOT_API_KEY",
   },
 };

--- a/codex-cli/tests/cancel-exec.test.ts
+++ b/codex-cli/tests/cancel-exec.test.ts
@@ -25,6 +25,7 @@ describe("exec cancellation", () => {
     abortController.abort();
 
     const result = await promise;
+    expect(result.pid).toBeGreaterThan(0);
     const durationMs = Date.now() - start;
 
     // The process should have been terminated rapidly (well under the 5s the
@@ -49,6 +50,7 @@ describe("exec cancellation", () => {
     const cmd = ["node", "-e", "console.log('finished')"];
 
     const result = await rawExec(cmd, {}, config, abortController.signal);
+    expect(result.pid).toBeGreaterThan(0);
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout.trim()).toBe("finished");

--- a/codex-cli/tests/invalid-command-handling.test.ts
+++ b/codex-cli/tests/invalid-command-handling.test.ts
@@ -11,6 +11,7 @@ describe("rawExec – invalid command handling", () => {
     const cmd = ["definitely-not-a-command-1234567890"];
     const config = { model: "any", instructions: "" } as AppConfig;
     const result = await rawExec(cmd, {}, config);
+    expect(result.pid).toBe(0);
 
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- handle login via GitHub device flow
- save Copilot token in auth.json
- create `GithubCopilotClient` for Copilot API requests
- initialize Copilot client in agent loop
- expose `githubcopilot` provider configuration
- ensure aborted rawExec kills entire process group and return PID

## Testing
- `pnpm --filter @openai/codex run format`
- `pnpm --filter @openai/codex run lint`
- `pnpm --filter @openai/codex run typecheck`
- `pnpm --filter @openai/codex run test`

------
https://chatgpt.com/codex/tasks/task_e_684f272bac248326a07facb43efee33f